### PR TITLE
add activateCrossSite to the $soapProvider

### DIFF
--- a/angular.soap.js
+++ b/angular.soap.js
@@ -1,3 +1,5 @@
+var withCredentials = false;
+
 angular.module('angularSoap', [])
 
 .provider("$soap", function $soapProvider() {
@@ -10,7 +12,6 @@ angular.module('angularSoap', [])
 	/**
 	 * Call activateCrossSite() to use credentials on cross-site Access-Control requests.
 	 */
-	var withCredentials = false;
 	this.activateCrossSite = function activateCrossSite() {
 		withCredentials = true;
 	}

--- a/angular.soap.js
+++ b/angular.soap.js
@@ -7,6 +7,14 @@ angular.module('angularSoap', [])
 		logsActivated = true;
 	};
 
+	/**
+	 * Call activateCrossSite() to use credentials on cross-site Access-Control requests.
+	 */
+	var withCredentials = false;
+	this.activateCrossSite = function activateCrossSite() {
+		withCredentials = true;
+	}
+
 	this.$get = ['$q',function($q){
 		return {
 			post: function(url, action, params){
@@ -32,7 +40,7 @@ angular.module('angularSoap', [])
 					console.log(url, action, params);
 				}
 
-				SOAPClient.invoke(url, action, soapParams, true, soapCallback);
+				SOAPClient.invoke(url, action, soapParams, true, soapCallback, withCredentials);
 
 				return deferred.promise;
 			},

--- a/soapclient.js
+++ b/soapclient.js
@@ -178,24 +178,24 @@ function SOAPClient() {}
 SOAPClient.username = null;
 SOAPClient.password = null;
 
-SOAPClient.invoke = function(url, method, parameters, async, callback, withCredentials)
+SOAPClient.invoke = function(url, method, parameters, async, callback)
 {
   if(async)
-    SOAPClient._loadWsdl(url, method, parameters, async, callback, withCredentials);
+    SOAPClient._loadWsdl(url, method, parameters, async, callback);
   else
-    return SOAPClient._loadWsdl(url, method, parameters, async, callback, withCredentials);
+    return SOAPClient._loadWsdl(url, method, parameters, async, callback);
 }
 
 // private: wsdl cache
 SOAPClient_cacheWsdl = new Array();
 
 // private: invoke async
-SOAPClient._loadWsdl = function(url, method, parameters, async, callback, withCredentials)
+SOAPClient._loadWsdl = function(url, method, parameters, async, callback)
 {
   // load from cache?
   var wsdl = SOAPClient_cacheWsdl[url];
   if(wsdl + "" != "" && wsdl + "" != "undefined")
-    return SOAPClient._sendSoapRequest(url, method, parameters, async, callback, withCredentials, wsdl);
+    return SOAPClient._sendSoapRequest(url, method, parameters, async, callback, wsdl);
   // get wsdl
   var xmlHttp = SOAPClient._getXmlHttp();
   xmlHttp.open("GET", url + "?wsdl", async);
@@ -206,20 +206,20 @@ SOAPClient._loadWsdl = function(url, method, parameters, async, callback, withCr
     xmlHttp.onreadystatechange = function()
     {
       if(xmlHttp.readyState == 4)
-        SOAPClient._onLoadWsdl(url, method, parameters, async, callback, withCredentials, xmlHttp);
+        SOAPClient._onLoadWsdl(url, method, parameters, async, callback, xmlHttp);
     }
   }
   xmlHttp.send(null);
   if (!async)
-    return SOAPClient._onLoadWsdl(url, method, parameters, async, callback, withCredentials, xmlHttp);
+    return SOAPClient._onLoadWsdl(url, method, parameters, async, callback, xmlHttp);
 }
-SOAPClient._onLoadWsdl = function(url, method, parameters, async, callback, withCredentials, req)
+SOAPClient._onLoadWsdl = function(url, method, parameters, async, callback, req)
 {
   var wsdl = req.responseXML;
   SOAPClient_cacheWsdl[url] = wsdl;	// save a copy in cache
-  return SOAPClient._sendSoapRequest(url, method, parameters, async, callback, withCredentials, wsdl);
+  return SOAPClient._sendSoapRequest(url, method, parameters, async, callback, wsdl);
 }
-SOAPClient._sendSoapRequest = function(url, method, parameters, async, callback, withCredentials, wsdl)
+SOAPClient._sendSoapRequest = function(url, method, parameters, async, callback, wsdl)
 {
   // get namespace
   var ns = (wsdl.documentElement.attributes["targetNamespace"] + "" == "undefined") ? wsdl.documentElement.attributes.getNamedItem("targetNamespace").nodeValue : wsdl.documentElement.attributes["targetNamespace"].value;
@@ -236,9 +236,7 @@ SOAPClient._sendSoapRequest = function(url, method, parameters, async, callback,
     "</" + method + "></s:Body></s:Envelope>";
   // send request
   var xmlHttp = SOAPClient._getXmlHttp();
-  if(withCredentials){
-    xmlHttp.withCredentials = true;
-  }
+  xmlHttp.withCredentials = withCredentials;
   if (SOAPClient.userName && SOAPClient.password){
     xmlHttp.open("POST", url, async, SOAPClient.userName, SOAPClient.password);
     // Some WS implementations (i.e. BEA WebLogic Server 10.0 JAX-WS) don't support Challenge/Response HTTP BASIC, so we send authorization headers in the first request


### PR DESCRIPTION
Enables the user to use credentials on cross-site Access-Control requests.

Usage: 

``` js
angular
  .module('app', ['angularSoap']
  .config(function($soapProvider) {
      $soapProvider.activateCrossSite();
   })
```
